### PR TITLE
Added OSGi Bundle-NativeCode entry to support Windows 8.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -371,6 +371,10 @@ com/sun/jna/win32-x86/jnidispatch.dll;
 processor=x86;osname=win32,
 com/sun/jna/win32-x86-64/jnidispatch.dll;
 processor=x86-64;osname=win32,
+com/sun/jna/win32-x86/jnidispatch.dll;
+processor=x86;osname=win,
+com/sun/jna/win32-x86-64/jnidispatch.dll;
+processor=x86-64;osname=win,
 com/sun/jna/w32ce-arm/jnidispatch.dll;
 processor=arm;osname=wince,
 


### PR DESCRIPTION
Hi Timothy,

as discussed on the user forum, a patch that will ensure the JNA package can be installed in an OSGi container running on Windows 8.1. There are 2 options to consider:

On the proposed path, we could make the additional native library entry also version specific by adding `...;osname=win;osversion=6.3.0` to make sure that entry only matches on windows 8.1, but that would break as soon as Windows decides to bump that number and there is no wildcard support in Apache Felix as far as I can see to specify something like `6.*.*`. So this is more a FYI than a workable option I guess.

The other alternative would be to add a `*` at the very end to effectively bypass the OSGi container check, but I can see from comments in the build.xml file that it should specifically fail on platforms that are not supported.

Hope suggested "workaround" will work for you. Sorry did not test this specific build, am not setup for make, gcc atm but I did test the configuration on a shaded bundle where I regenerate the manifest.

Cheers,
Niels