### PR TITLE
Added mappings for XGrabKeyboard and XUngrabKeyboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Features
 * [#400](https://github.com/twall/jna/pull/400): Added specific constants for request of icon settings in `com.sun.jna.platform.win32.WinUser` - [@PAX523](https://github.com/PAX523).
 * [#400](https://github.com/twall/jna/pull/400): Added constants for `GetClassLong`, `SendMessageTimeout` and `GetIconInfo` in `com.sun.jna.platform.win32.WinUser` - [@PAX523](https://github.com/PAX523).
 * [#419](https://github.com/twall/jna/pull/419): Added `SetupDiOpenDevRegKey` , `SetupDiEnumDeviceInfo` and related constants to `com.sun.jna.platform.win32.SetupApi` - [@ChristianSchwarz](https://github.com/ChristianSchwarz).
+* [#421](https://github.com/twall/jna/pull/421): Added `XGrabKeyboard` and `XUngrabKeyboard` to `X11` interface.
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/unix/X11.java
+++ b/contrib/platform/src/com/sun/jna/platform/unix/X11.java
@@ -1953,6 +1953,27 @@ public interface X11 extends Library {
      */
     int XUngrabKey(Display display, int keyCode, int modifiers, Window grab_window);
 
+    /**
+     * Actively grabs control of the keyboard and generates FocusIn and FocusOut events
+     *
+     * @param display Specifies the connection to the X server.
+     * @param grab_window Specifies the grab window.
+     * @param owner_events Specifies a Boolean value that indicates whether the keyboard events are to be reported as usual.
+     * @param pointer_mode Specifies further processing of pointer events. You can pass GrabModeSync or GrabModeAsync.
+     * @param keyboard_mode Specifies further processing of keyboard events. You can pass GrabModeSync or GrabModeAsync.
+     * @param time Specifies the time. You can pass either a timestamp or CurrentTime.
+     * @return nothing
+     */
+    int XGrabKeyboard(Display display, Window grab_window, int owner_events, int pointer_mode, int keyboard_mode, NativeLong time);
+
+    /**
+     * Releases the keyboard and any queued events if this client has it actively grabbed from either XGrabKeyboard() or XGrabKey().
+     * @param display Specifies the connection to the X server.
+     * @param time Specifies the time. You can pass either a timestamp or CurrentTime.
+     * @return nothing
+     */
+    int XUngrabKeyboard(Display display, NativeLong time);
+
     //int XChangeKeyboardMapping(Display display, int first_keycode, int keysyms_per_keycode, KeySym *keysyms, int num_codes);
     /** Defines the symbols for the specified number of KeyCodes starting with first_keycode. The symbols for KeyCodes outside this range remain unchanged. The number of elements in keysyms must be: num_codes * keysyms_per_keycode. The specified first_keycode must be greater than or equal to min_keycode returned by XDisplayKeycodes, or a BadValue error results. In addition, the following expression must be less than or equal to max_keycode as returned by XDisplayKeycodes, or a BadValue error results: first_keycode + num_codes - 1. */
     int XChangeKeyboardMapping(Display display, int first_keycode, int keysyms_per_keycode, KeySym[] keysyms, int num_codes);


### PR DESCRIPTION
Simply added mappings for those 2 functions.
Documentation taken from http://tronche.com/gui/x/xlib/input/XGrabKeyboard.html and Xlib.h.