### PR TITLE
Add gettext as a requirement for the Mac build notes.

### DIFF
--- a/www/MacDevelopmentEnvironment.md
+++ b/www/MacDevelopmentEnvironment.md
@@ -11,25 +11,25 @@ Mac Development Environment
 
 * Various build tools are also required. You can install these using [brew](http://brew.sh).
 
-        $ brew install autoconf automake libtool
-        
+        $ brew install autoconf automake libtool gettext
+
     If you are missing these tools, when you build you are likely to see errors like those below:
-      
+
         native:
              [exec] Generating configure
              [exec] ./autogen.sh: line 2: exec: autoreconf: not found
 
     or
-    
+
         [exec] Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
         [exec] autoreconf: failed to run aclocal: No such file or directory
 
     or
-        
+
         [exec] configure.ac:41: error: possibly undefined macro: AC_PROG_LIBTOOL
 
     or
-    
+
         native:
             [exec] Configuring libffi (x86_64)
             [exec] configure: WARNING: unrecognized options: --enable-static, --disable-shared, --with-pic


### PR DESCRIPTION
When I tried to build JNA on my Mac I also had to install gettext. Before doing so, I would see the error `[exec] configure: WARNING: unrecognized options: --enable-static, --disable-shared, --with-pic` (which is already in the document describing how to build on Mac OS).