### PR TITLE
Cleanup of temporarily extracted files in case of errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ Features
 
 Bug Fixes
 ---------
+* [#450](https://github.com/twall/jna/pull/450): Libraries extracted to temp directory are now cleaned up in case of library loading errors, as well - [@aschnab](https://github.com/aschnab).
 * [#319](https://github.com/twall/jna/pull/319): Fix direct-mapping type-mapped pointer result types - [@marco2357](https://github.com/marco2357).
 * [#350](https://github.com/twall/jna/pull/350): Fix `jnacontrib.x11.api.X.Window.getXXXProperty`, returns `null` if the window property is not found - [@rm5248](https://github.com/rm5248).
 * Fixed `com.sun.jna.platform.win32.Variant` and `TlbImp` - [@wolftobias](https://github.com/wolftobias).

--- a/src/com/sun/jna/NativeLibrary.java
+++ b/src/com/sun/jna/NativeLibrary.java
@@ -257,11 +257,14 @@ public class NativeLibrary {
             if (handle == 0) {
                 try {
                     File embedded = Native.extractFromResourcePath(libraryName, (ClassLoader)options.get(Library.OPTION_CLASSLOADER));
-                    handle = Native.open(embedded.getAbsolutePath(), openFlags);
-                    libraryPath = embedded.getAbsolutePath();
-                    // Don't leave temporary files around
-                    if (Native.isUnpacked(embedded)) {
-                        Native.deleteLibrary(embedded);
+                    try {
+                        handle = Native.open(embedded.getAbsolutePath(), openFlags);
+                        libraryPath = embedded.getAbsolutePath();
+                    } finally {
+                        // Don't leave temporary files around
+                        if (Native.isUnpacked(embedded)) {
+                            Native.deleteLibrary(embedded);
+                        }
                     }
                 }
                 catch(IOException e2) { e = new UnsatisfiedLinkError(e2.getMessage()); }


### PR DESCRIPTION
If an Exception/UnsatisfiedLinkError is thrown during the Native.open() call on a library file that has been extracted from the resource path, the extracted library file is not immediately cleaned up: the files only disappear once the using application shuts down, thanks to the deleteOnExit() called upon them in Native.extractFromResourcePath(). However, if the using application keeps (unsuccessfully) retrying to call Native.loadLibrary(), this can fill up the temporary JNA directory rather quickly.

This little change should counteract this scenario.