### PR TITLE
Added volume management functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Features
 * [#434](https://github.com/twall/jna/pull/434): Added GetEnvironmentStrings to 'com.sun.jna.platform.win32.Kernel32'  - [@lgoldstein](https://github.com/lgoldstein).
 * Loosen OSGI OS name matching to accommodate Windows 8 family - Niels Bertram.
 * [#436] (https://github.com/twall/jna/pull/469): Added basic Pdh API implementation to 'com.sun.jna.platform.win32' - [@lgoldstein](https://github.com/lgoldstein).
+* [#481] (https://github.com/twall/jna/pull/481): Added volume management functions to 'com.sun.jna.platform.win32' - [@lgoldstein](https://github.com/lgoldstein).
 
 Bug Fixes
 ---------

--- a/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
+++ b/contrib/platform/src/com/sun/jna/platform/win32/WinNT.java
@@ -722,6 +722,19 @@ public interface WinNT extends WinError, WinDef, WinBase, BaseTSD {
     int FILE_READ_ONLY_VOLUME = 0x00080000;
     int FILE_SEQUENTIAL_WRITE_ONCE = 0x00100000;
     int FILE_SUPPORTS_TRANSACTIONS = 0x00200000;
+    // NOTE: These values are not supported until Windows Server 2008 R2 and Windows 7
+    int FILE_SUPPORTS_HARD_LINKS = 0x00400000;
+    int FILE_SUPPORTS_EXTENDED_ATTRIBUTES = 0x00800000;
+    int FILE_SUPPORTS_OPEN_BY_FILE_ID = 0x01000000;
+    int FILE_SUPPORTS_USN_JOURNAL = 0x02000000;
+
+    
+    // The controllable aspects of the DefineDosDevice function.
+    // see https://msdn.microsoft.com/en-us/library/windows/desktop/aa363904(v=vs.85).aspx
+    int DDD_RAW_TARGET_PATH = 0x00000001;
+    int DDD_REMOVE_DEFINITION = 0x00000002;
+    int DDD_EXACT_MATCH_ON_REMOVE = 0x00000004;
+    int DDD_NO_BROADCAST_SYSTEM = 0x00000008;
 
     /**
      * The FILE_NOTIFY_INFORMATION structure describes the changes found by the

--- a/contrib/platform/test/com/sun/jna/platform/win32/AbstractWin32TestSupport.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/AbstractWin32TestSupport.java
@@ -13,6 +13,7 @@
 package com.sun.jna.platform.win32;
 
 import com.sun.jna.platform.AbstractPlatformTestSupport;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
 
 /**
  * @author lgoldstein
@@ -35,11 +36,11 @@ public abstract class AbstractWin32TestSupport extends AbstractPlatformTestSuppo
             return;
         }
         
-        int hr=Kernel32.INSTANCE.GetLastError();
+        int hr = Kernel32.INSTANCE.GetLastError();
         if (hr == WinError.ERROR_SUCCESS) {
             fail(message + " failed with unknown reason code");
         } else {
-            fail(message + " failed: hr=0x" + Integer.toHexString(hr));
+            fail(message + " failed: hr=" + hr + " - 0x" + Integer.toHexString(hr));
         }
     }
     
@@ -57,5 +58,27 @@ public abstract class AbstractWin32TestSupport extends AbstractPlatformTestSuppo
         } else {
             assertEquals(message, WinError.ERROR_SUCCESS, statusCode);
         }
+    }
+    
+    /**
+     * Makes sure that the handle argument is not {@code null} or {@link WinBase#INVALID_HANDLE_VALUE}.
+     * If invalid handle detected, then it invokes {@link Kernel32#GetLastError()}
+     * in order to display the error code
+     * @param message Message to display if bad handle
+     * @param handle The {@link HANDLE} to test
+     * @return The same as the input handle if good handle - otherwise does
+     * not return and throws an assertion error
+     */
+    public static final HANDLE assertValidHandle(String message, HANDLE handle) {
+        if ((handle == null) || WinBase.INVALID_HANDLE_VALUE.equals(handle)) {
+            int hr = Kernel32.INSTANCE.GetLastError();
+            if (hr == WinError.ERROR_SUCCESS) {
+                fail(message + " failed with unknown reason code");
+            } else {
+                fail(message + " failed: hr=" + hr + " - 0x" + Integer.toHexString(hr));
+            }
+        }
+
+        return handle;
     }
 }

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32Test.java
@@ -399,13 +399,6 @@ public class Kernel32Test extends TestCase {
     	assertEquals(0, lpBuffer.ullAvailExtendedVirtual.intValue());
     }
 
-    public void testGetLogicalDriveStrings() {
-    	DWORD dwSize = Kernel32.INSTANCE.GetLogicalDriveStrings(new DWORD(0), null);
-    	assertTrue(dwSize.intValue() > 0);
-    	char buf[] = new char[dwSize.intValue()];
-    	assertTrue(Kernel32.INSTANCE.GetLogicalDriveStrings(dwSize, buf).intValue() > 0);
-    }
-
     public void testGetDiskFreeSpaceEx() {
     	LARGE_INTEGER.ByReference lpFreeBytesAvailable = new LARGE_INTEGER.ByReference();
     	LARGE_INTEGER.ByReference lpTotalNumberOfBytes = new LARGE_INTEGER.ByReference();

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32UtilTest.java
@@ -19,10 +19,11 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-
-import junit.framework.TestCase;
+import java.util.Collection;
 
 import com.sun.jna.platform.win32.WinNT.LARGE_INTEGER;
+
+import junit.framework.TestCase;
 
 /**
  * @author dblock[at]dblock[dot]org
@@ -35,7 +36,7 @@ public class Kernel32UtilTest extends TestCase {
         System.out.println("Temp path: " + Kernel32Util.getTempPath());
         // logical drives
         System.out.println("Logical drives: ");
-		String[] logicalDrives = Kernel32Util.getLogicalDriveStrings();
+		Collection<String> logicalDrives = Kernel32Util.getLogicalDriveStrings();
 		for(String logicalDrive : logicalDrives) {
 			// drive type
 			System.out.println(" " + logicalDrive + " (" 
@@ -105,10 +106,10 @@ public class Kernel32UtilTest extends TestCase {
 	}
 	
 	public void testGetLogicalDriveStrings() {
-		String[] logicalDrives = Kernel32Util.getLogicalDriveStrings();
-		assertTrue(logicalDrives.length > 0);
+	    Collection<String> logicalDrives = Kernel32Util.getLogicalDriveStrings();
+		assertTrue("No logical drives found", logicalDrives.size() > 0);
 		for(String logicalDrive : logicalDrives) {
-			assertTrue(logicalDrive.length() > 0);
+			assertTrue("Empty logical drive name in list", logicalDrive.length() > 0);
 		}
 	}
 	

--- a/contrib/platform/test/com/sun/jna/platform/win32/Kernel32VolumeManagementFunctionsTest.java
+++ b/contrib/platform/test/com/sun/jna/platform/win32/Kernel32VolumeManagementFunctionsTest.java
@@ -1,0 +1,188 @@
+/* Copyright (c) 2007 Timothy Wall, All Rights Reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package com.sun.jna.platform.win32;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.sun.jna.Native;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.ptr.IntByReference;
+
+public class Kernel32VolumeManagementFunctionsTest extends AbstractWin32TestSupport {
+    public Kernel32VolumeManagementFunctionsTest() {
+        super();
+    }
+
+    @Test
+    public void testQueryDosDevice() {
+        Collection<String> logicalDrives = Kernel32Util.getLogicalDriveStrings();
+        for (String lpszDeviceName : logicalDrives) {
+            // the documentation states that the device name cannot have a trailing backslash
+            if (lpszDeviceName.charAt(lpszDeviceName.length() - 1) == File.separatorChar) {
+                lpszDeviceName = lpszDeviceName.substring(0, lpszDeviceName.length() - 1);
+            }
+            
+            Collection<String> devices = Kernel32Util.queryDosDevice(lpszDeviceName, WinBase.MAX_PATH);
+            assertTrue("No devices for " + lpszDeviceName, devices.size() > 0);
+            for (String name : devices) {
+                assertTrue("Empty device name for " + lpszDeviceName, name.length() > 0);
+//                System.out.append(getCurrentTestName()).append('[').append(lpszDeviceName).append(']').append(" - ").println(name);
+            }
+        }
+    }
+
+    @Test
+    public void testGetVolumePathName() {
+        char[] lpszVolumePathName = new char[WinDef.MAX_PATH + 1];
+        for (String propName : new String[] { "java.home", "java.io.tmpdir", "user.dir", "user.home" }) {
+            String lpszFileName = System.getProperty(propName);
+            assertCallSucceeded("GetVolumePathName(" + lpszFileName + ")",
+                    Kernel32.INSTANCE.GetVolumePathName(lpszFileName, lpszVolumePathName, lpszVolumePathName.length));
+            String path = Native.toString(lpszVolumePathName);
+//            System.out.append(getCurrentTestName()).append('[').append(lpszFileName).append(']').append(" - ").println(path);
+            assertTrue("No volume path for " + lpszFileName, path.length() > 0);
+        }
+    }
+
+    @Test
+    public void testGetVolumeNameForVolumeMountPoint() {
+        Collection<String> logicalDrives = Kernel32Util.getLogicalDriveStrings();
+        char[] lpVolumeNameBuffer = new char[WinDef.MAX_PATH + 1];
+        for (String lpszVolumeMountPoint : logicalDrives) {
+            // according to documentation path MUST end in backslash
+            if (lpszVolumeMountPoint.charAt(lpszVolumeMountPoint.length() - 1) != File.separatorChar) {
+                lpszVolumeMountPoint += File.separator;
+            }
+            
+            int driveType = Kernel32.INSTANCE.GetDriveType(lpszVolumeMountPoint);
+            // network mapped drives fail GetVolumeNameForVolumeMountPoint call 
+            if (driveType != WinBase.DRIVE_FIXED) {
+//                System.out.append('\t').append('[').append(lpszVolumeMountPoint).append(']').println(" - skipped: non-fixed drive");
+                continue;
+            }
+
+            if (Kernel32.INSTANCE.GetVolumeNameForVolumeMountPoint(lpszVolumeMountPoint, lpVolumeNameBuffer, lpVolumeNameBuffer.length)) {
+                String volumeGUID = Native.toString(lpVolumeNameBuffer);
+//                System.out.append(getCurrentTestName()).append('[').append(lpszVolumeMountPoint).append(']').append(" - ").println(volumeGUID);
+                assertTrue("Empty GUID for " + lpszVolumeMountPoint, volumeGUID.length() > 0);
+            } else {
+                int hr = Kernel32.INSTANCE.GetLastError();
+                if ((hr == WinError.ERROR_ACCESS_DENIED)    // e.g., hidden volumes
+                 || (hr == WinError.ERROR_NOT_READY)) {     // e.g., DVD drive
+//                    System.out.append('\t').append('[').append(lpszVolumeMountPoint).append(']').append(" - skipped: reason=").println(hr);
+                    continue;
+                }
+                
+                fail("Cannot (error=" + hr + ") get volume information mount point " + lpszVolumeMountPoint);
+            }
+        }
+    }
+
+    @Test
+    public void testGetVolumeInformation() {
+        List<String> logicalDrives = Kernel32Util.getLogicalDriveStrings();
+        char[] lpVolumeNameBuffer = new char[WinDef.MAX_PATH + 1];
+        char[] lpFileSystemNameBuffer = new char[WinDef.MAX_PATH + 1];
+        IntByReference lpVolumeSerialNumber = new IntByReference();
+        IntByReference lpMaximumComponentLength = new IntByReference();
+        IntByReference lpFileSystemFlags = new IntByReference();
+
+        for (int index=(-1); index < logicalDrives.size(); index++) {
+            String lpRootPathName = (index < 0) ? null /* curdir */ : logicalDrives.get(index);
+            // according to documentation path MUST end in backslash
+            if ((lpRootPathName != null) && (lpRootPathName.charAt(lpRootPathName.length() - 1) != File.separatorChar)) {
+                lpRootPathName += File.separator;
+            }
+
+            if (!Kernel32.INSTANCE.GetVolumeInformation(lpRootPathName,
+                        lpVolumeNameBuffer, lpVolumeNameBuffer.length,
+                        lpVolumeSerialNumber, lpMaximumComponentLength, lpFileSystemFlags,
+                        lpFileSystemNameBuffer, lpFileSystemNameBuffer.length)) {
+                int hr = Kernel32.INSTANCE.GetLastError();
+                if ((hr == WinError.ERROR_ACCESS_DENIED)    // e.g., network or hidden volumes
+                 || (hr == WinError.ERROR_NOT_READY)) {     // e.g., DVD drive
+//                    System.out.append('\t').append('[').append(lpRootPathName).append(']').append(" - skipped: reason=").println(hr);
+                    continue;
+                }
+                
+                fail("Cannot (error=" + hr + ") get volume information for " + lpRootPathName);
+            }
+
+//            System.out.append(getCurrentTestName()).append('[').append(lpRootPathName).println(']');
+//            System.out.append('\t').append("Volume name: ").println(Native.toString(lpVolumeNameBuffer));
+//            System.out.append('\t').append("File system name: ").println(Native.toString(lpFileSystemNameBuffer));
+//            System.out.append('\t').append("Serial number: ").println(lpVolumeSerialNumber.getValue());
+//            System.out.append('\t').append("Max. component: ").println(lpMaximumComponentLength.getValue());
+//            System.out.append('\t').append("File system flags: 0x").println(Integer.toHexString(lpFileSystemFlags.getValue()));
+        }
+    }
+
+    @Test
+    public void testEnumVolumes() {
+        char[] lpszVolumeName = new char[WinDef.MAX_PATH + 1];
+        HANDLE hFindVolume = assertValidHandle("FindFirstVolume", Kernel32.INSTANCE.FindFirstVolume(lpszVolumeName, lpszVolumeName.length));
+        try {
+            do {
+                String volumeGUID = Native.toString(lpszVolumeName);
+                testEnumVolumeMountMoints(volumeGUID);
+                testGetVolumePathNamesForVolumeName(volumeGUID);
+            } while(Kernel32.INSTANCE.FindNextVolume(hFindVolume, lpszVolumeName, lpszVolumeName.length));
+            
+            int hr = Kernel32.INSTANCE.GetLastError();
+            assertEquals("Bad volumes enum termination reason", WinError.ERROR_NO_MORE_FILES, hr);
+        } finally {
+            assertCallSucceeded("FindVolumeClose", Kernel32.INSTANCE.FindVolumeClose(hFindVolume));
+        }
+    }
+    
+    private void testGetVolumePathNamesForVolumeName(String lpszVolumeName) {
+        Collection<String> paths = Kernel32Util.getVolumePathNamesForVolumeName(lpszVolumeName);
+        assertTrue("No paths for volume " + lpszVolumeName, paths.size() > 0);
+        for (String p : paths) {
+//            System.out.append('\t').append("testGetVolumePathNamesForVolumeName").append('[').append(lpszVolumeName).append(']').append(" - ").println(p);
+            assertTrue("Empty path for volume " + lpszVolumeName, p.length() > 0);
+        }
+    }
+
+    private void testEnumVolumeMountMoints(String volumeGUID) {
+        char[] lpszVolumeMountPoint = new char[WinDef.MAX_PATH + 1];
+        HANDLE hFindVolumeMountPoint = Kernel32.INSTANCE.FindFirstVolumeMountPoint(volumeGUID, lpszVolumeMountPoint, lpszVolumeMountPoint.length);
+        if (WinNT.INVALID_HANDLE_VALUE.equals(hFindVolumeMountPoint)) {
+            int hr = Kernel32.INSTANCE.GetLastError();
+            if ((hr == WinError.ERROR_ACCESS_DENIED)    // e.g., network or hidden volumes
+             || (hr == WinError.ERROR_NOT_READY)) {     // e.g., DVD drive
+//                System.out.append('\t').append('[').append(volumeGUID).append(']').append(" - skipped: reason=").println(hr);
+                return;
+            }
+            
+            fail("Cannot (error=" + hr + ") open mount point search handle for " + volumeGUID);
+        }
+
+        try {
+            do {
+                String name = Native.toString(lpszVolumeMountPoint);
+                assertTrue("Empty mount point for " + volumeGUID, name.length() > 0);
+//                System.out.append('\t').append("testEnumVolumeMountMoints").append('[').append(volumeGUID).append(']').append(" - ").println(name);
+            } while(Kernel32.INSTANCE.FindNextVolumeMountPoint(hFindVolumeMountPoint, lpszVolumeMountPoint, lpszVolumeMountPoint.length));
+            
+            int hr = Kernel32.INSTANCE.GetLastError();
+            assertEquals("Mount points enum termination reason for " + volumeGUID, WinError.ERROR_NO_MORE_FILES, hr);
+        } finally {
+            assertCallSucceeded("FindVolumeMountPointClose(" + volumeGUID + ")", Kernel32.INSTANCE.FindVolumeMountPointClose(hFindVolumeMountPoint));
+        }
+    }
+}

--- a/test/com/sun/jna/NativeTest.java
+++ b/test/com/sun/jna/NativeTest.java
@@ -82,6 +82,23 @@ public class NativeTest extends TestCase {
                      UNICODE, Native.toString(UNICODEZ.getBytes(ENCODING), ENCODING));
     }
     
+    public void testToStringList() {
+        List<String> expected = Arrays.asList(getClass().getPackage().getName(), getClass().getSimpleName(), "testToStringList");
+        StringBuilder sb = new StringBuilder();
+        for (String value : expected) {
+            sb.append(value).append('\0');
+        }
+        sb.append('\0');
+        
+        List<String> actual = Native.toStringList(sb.toString().toCharArray());
+        assertEquals("Mismatched result size", expected.size(), actual.size());
+        for (int index = 0; index < expected.size(); index++) {
+            String expValue = expected.get(index);
+            String actValue = actual.get(index);
+            assertEquals("Mismatched value at index #" + index, expValue, actValue);
+        }
+    }
+
     public void testDefaultStringEncoding() throws Exception {
         final String UNICODE = "\u0444\u043b\u0441\u0432\u0443";
         final String UNICODEZ = UNICODE + "\0more stuff";


### PR DESCRIPTION
- Added (almost) all the functions under [Volume Management Functions](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365730(v=vs.85).aspx) including tests - except for the functions that might affect the host running the test (e.g., _SetVolumeLabel_)

- Improved efficiency of _Native#toString(...)_ to avoid creation of extra strings by pre-detecting the NULL terminator position

- Added _Native#toStringList()_ since it is very common to find double-null terminated string buffers. I used it also in _Kernel32Util#getLogicalDrives_ and changed its return type from and array to a list accordingly.